### PR TITLE
Fix broken XFF with 1 proxy

### DIFF
--- a/index.js
+++ b/index.js
@@ -147,7 +147,7 @@ ExpressBrute.prototype.getIPFromRequest = function (req) {
 		var ips = req.get('X-Forwarded-For').split(/ *, */);
 		if (this.options.proxyDepth < ips.length) {
 			return ips[ips.length - this.options.proxyDepth - 1];
-		} else if (ips.length > 1) {
+		} else if (ips.length >= 1) {
 			return ips[0];
 		}
 	}


### PR DESCRIPTION
When setting proxyDepth to 1, ips is never populated with proxied X-Forwarded-For IP.
pseudo code before changes :

```
if (1 < 1) { ... } else if (1 > 1) { ... }
```
