### PR TITLE
Fixed bug where proxyDepth would skip the nearest proxy IP.

### DIFF
--- a/index.js
+++ b/index.js
@@ -175,7 +175,7 @@ ExpressBrute.prototype.getIPFromRequest = function (req) {
 	if (this.options.proxyDepth && this.options.proxyDepth > 0 && req.get('X-Forwarded-For')) {
 		var ips = req.get('X-Forwarded-For').split(/ *, */);
 		if (this.options.proxyDepth < ips.length) {
-			return ips[ips.length - this.options.proxyDepth - 1];
+			return ips[ips.length - this.options.proxyDepth];
 		} else if (ips.length >= 1) {
 			return ips[0];
 		}

--- a/spec/ExpessBrute.js
+++ b/spec/ExpessBrute.js
@@ -367,7 +367,7 @@ describe("express brute", function () {
 						remoteAddress: '1.2.3.4'
 					},
 					get: function () {
-						return '4.5.6.7, 3.4.5.6, 2.3.4.5, 1.2.3.4';
+						return '4.5.6.7, 3.4.5.6, 2.3.4.5';
 					}
 				};
 			};


### PR DESCRIPTION
Through testing an express app behind a load balancer, I discovered that it was possible to spoof the X-Forwarded-For header with a proxyDepth of 1.  Since setting proxyDepth to 0 skips checking of the X-Forwarded-For header altogether, I made a small modification to let proxyDepth=1 use the last IP address in the header.

For example, if I wanted to use the IP address of 1.1.1.1 in the following header, it was not possible before:
X-Forwarded-For: 2.2.2.2, 1.1.1.1

Now, using proxyDepth of 1 will use 1.1.1.1 instead of 2.2.2.2.  And proxyDepth of 2 would use 2.2.2.2, and so forth.