### PR TITLE
Added fix to allow for time skew within freeRetries

### DIFF
--- a/index.js
+++ b/index.js
@@ -123,7 +123,7 @@ ExpressBrute.prototype.getMiddleware = function (options) {
 					}
 				}
 
-				if (nextValidRequestTime <= this.now()) {
+				if (nextValidRequestTime <= this.now() || count <= this.options.freeRetries) {
 					this.store.set(key, {
 						count: count+1,
 						lastRequest: new Date(this.now()),

--- a/spec/ExpessBrute.js
+++ b/spec/ExpessBrute.js
@@ -56,6 +56,20 @@ describe("express brute", function () {
 			brute.prevent(req(), new ResponseMock(), nextSpy);
 			errorSpy.should.have.been.called;
 		});
+		it('respects free retries even with clock skew', function() {
+			brute = new ExpressBrute(store, {
+				freeRetries: 1,
+				minWait: 10,
+				maxWait: 100,
+				failCallback: errorSpy
+			});
+			brute.prevent(req(), new ResponseMock(), nextSpy);
+			clock.tick(-100);
+			brute.prevent(req(), new ResponseMock(), nextSpy);
+			errorSpy.should.not.have.been.called;
+			brute.prevent(req(), new ResponseMock(), nextSpy);
+			errorSpy.should.have.been.called;
+		});
 		it('correctly calculates delays when min and max wait are the same', function () {
 			brute = new ExpressBrute(store, {
 				freeRetries: 0,


### PR DESCRIPTION
We've been running into intermittent failures due to a slower clock on of our app servers.  This should correct it for most use cases.