### PR TITLE
readme: more visible warning for MemoryStore

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ A Simple Example
 ``` js
 var ExpressBrute = require('express-brute');
 
-var store = new ExpressBrute.MemoryStore(); // stores state locally, don't use this in production
+// stores state locally, don't use this in production
+var store = new ExpressBrute.MemoryStore();
 var bruteforce = new ExpressBrute(store);
 
 app.post('/auth',


### PR DESCRIPTION
just a suggestion to make this more visible, npm has less columns characters for the readmes

https://www.npmjs.com/package/express-brute

before : 
<img width="672" alt="capture d ecran 2017-10-17 a 00 58 47" src="https://user-images.githubusercontent.com/124937/31639022-eb819c38-b2d6-11e7-8bd9-260329ea8548.png">


after:
<img width="688" alt="capture d ecran 2017-10-17 a 00 59 37" src="https://user-images.githubusercontent.com/124937/31639017-e9330598-b2d6-11e7-944a-e66076aea783.png">

