### PR TITLE
Fix crypto hash update invalid arg type error

### DIFF
--- a/index.js
+++ b/index.js
@@ -196,7 +196,7 @@ ExpressBrute._getKey = function (arr) {
 	var key = '';
 	_(arr).each(function (part) {
 		if (part) {
-			key += crypto.createHash('sha256').update(part).digest('base64');
+			key += crypto.createHash('sha256').update(String(part)).digest('base64');
 		}
 	});
 	return crypto.createHash('sha256').update(key).digest('base64');


### PR DESCRIPTION
Error happen when you provide a number as custom key:

```
TypeError [ERR_INVALID_ARG_TYPE]: The "data" argument must be one of type string, TypedArray, or DataView
    at Hash.update (internal/crypto/hash.js:53:11)
    at ...
```

To fix that, just force key parts to be a `String`